### PR TITLE
[IDA-471] Add additional folder called "course_settings" to the exported imscc file

### DIFF
--- a/src/imscc/coursePackager/manifest/manifest.ts
+++ b/src/imscc/coursePackager/manifest/manifest.ts
@@ -90,7 +90,7 @@ const resourceTemplate = ({
   identifier,
   type,
   href,
-  file,
+  files,
   dependencies,
 }: ImsResource) => {
   const hrefAttr = href ? ` href="${href}"` : "";
@@ -102,8 +102,14 @@ const resourceTemplate = ({
           )
           .join("\n")}`
       : "";
-  const fileTag = file ? `\n${indent(`<file href="${file.href}"/>`)}` : "";
-  const template = `<resource identifier="${identifier}" type="${type}"${hrefAttr}>${fileTag}${dependencyTags}
+
+  const fileTags =
+    files && files.length > 0
+      ? `\n${files
+          .map((file) => indent(`<file href="${file.href}"/>`))
+          .join("\n")}`
+      : "";
+  const template = `<resource identifier="${identifier}" type="${type}"${hrefAttr}>${fileTags}${dependencyTags}
 </resource>`;
   return indent(template);
 };

--- a/src/imscc/coursePackager/manifest/types.ts
+++ b/src/imscc/coursePackager/manifest/types.ts
@@ -23,7 +23,7 @@ export interface ImsItem {
 export interface ImsResource {
   type: ImsResourceType;
   identifier: string;
-  file: ImsFile;
+  files: ImsFile[];
   href?: string;
   dependencies?: string[];
 }

--- a/src/imscc/coursePackager/moduleMeta/moduleMeta.ts
+++ b/src/imscc/coursePackager/moduleMeta/moduleMeta.ts
@@ -1,0 +1,47 @@
+import { ImsItem } from "../manifest/types";
+
+const itemTemplate = (item: ImsItem, index: number) => `
+    <item identifier="${item.identifier}">
+        <content_type>WikiPage</content_type>
+        <workflow_state>active</workflow_state>
+        <title>${item.title}</title>
+        <identifierref>${item.identifierRef}</identifierref>
+        <position>${index + 1}</position>
+        <new_tab />
+        <indent>0</indent>
+        <link_settings_json>null</link_settings_json>
+    </item>`;
+
+const itemsTemplate = (items: ImsItem[]) => `
+    <items>
+        ${
+          items && items.length > 0
+            ? items.map((item, index) => itemTemplate(item, index)).join("\n")
+            : ""
+        }
+    </items>`;
+
+const moduleTemplate = (module: ImsItem, index: number) => `  
+    <module identifier="${module.identifier}">
+    <title>${module.title}</title>
+    <workflow_state>active</workflow_state>
+    <position>${index + 1}</position>
+    <locked>false</locked>
+    ${itemsTemplate(module.items || [])}
+    </module>
+`;
+
+export const moduleMetaTemplate = (
+  modules: ImsItem[]
+) => `<?xml version="1.0" encoding="UTF-8"?>
+      <modules xmlns="http://canvas.instructure.com/xsd/cccv1p0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://canvas.instructure.com/xsd/cccv1p0 https://canvas.instructure.com/xsd/cccv1p0.xsd">
+        ${
+          modules && modules.length > 0
+            ? modules
+                .map((module, index) => moduleTemplate(module, index))
+                .join("\n")
+            : ""
+        }
+      </modules>`;

--- a/src/imscc/coursePackager/packager.ts
+++ b/src/imscc/coursePackager/packager.ts
@@ -20,9 +20,9 @@ const moduleItem = (module: ResourceModule): ImsItem => ({
   ),
 });
 
-const courseSetting = (courseTitle: string) => `
+const courseSetting = (courseTitle: string, courseSettingId: string) => `
 <?xml version="1.0" encoding="UTF-8"?>
-<course identifier="COURSE_SETTINGS_abcdefghijk"
+<course identifier="${courseSettingId}"
   xmlns="http://canvas.instructure.com/xsd/cccv1p0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://canvas.instructure.com/xsd/cccv1p0 https://canvas.instructure.com/xsd/cccv1p0.xsd">
@@ -164,7 +164,10 @@ export const packageCourse = async (
   };
 
   // course_settings.xml (mostly empty placeholder)
-  zip.file("course_settings/course_settings.xml", courseSetting);
+  zip.file(
+    "course_settings/course_settings.xml",
+    courseSetting(courseContent.title, courseSettingResources.identifier)
+  );
 
   // module_meta.xml (re-iterates the module layout)
   zip.file(

--- a/src/imscc/coursePackager/packager.ts
+++ b/src/imscc/coursePackager/packager.ts
@@ -116,34 +116,32 @@ export const packageCourse = async (
     []
   );
 
-  const courseSettingResources: ImsResource[] = [
-    {
-      identifier: randomId("COURSE_SETTINGS"),
-      type: "associatedcontent/imscc_xmlv1p1/learning-application-resource",
-      files: [
-        {
-          href: "course_settings/course_settings.xml",
-        },
-        {
-          href: "course_settings/module_meta.xml",
-        },
-        {
-          href: "course_settings/files_meta.xml",
-        },
-        {
-          href: "course_settings/canvas_export.txt",
-        },
-      ],
-    },
-  ];
-
+  const courseSettingResources: ImsResource = {
+    identifier: randomId("COURSE_SETTINGS"),
+    type: "associatedcontent/imscc_xmlv1p1/learning-application-resource",
+    files: [
+      {
+        href: "course_settings/course_settings.xml",
+      },
+      {
+        href: "course_settings/module_meta.xml",
+      },
+      {
+        href: "course_settings/files_meta.xml",
+      },
+      {
+        href: "course_settings/canvas_export.txt",
+      },
+    ],
+  };
   const organizationModuleItem: ImsItem[] = modules.map(moduleItem);
 
   const resources = resourcePages
     .map(pageResource)
     .concat(attachmentResources)
-    .concat(globalDependencies)
-    .concat(courseSettingResources);
+    .concat(globalDependencies);
+
+  resources.push(courseSettingResources);
 
   const manifest: ImsManifest = {
     generatorComment,

--- a/src/imscc/coursePackager/packager.ts
+++ b/src/imscc/coursePackager/packager.ts
@@ -41,9 +41,11 @@ export const packageCourse = async (
     globalDependencies.push({
       identifier: randomId("CSS"),
       type: "webcontent",
-      file: {
-        href: path,
-      },
+      files: [
+        {
+          href: path,
+        },
+      ],
     });
   }
 
@@ -86,9 +88,11 @@ export const packageCourse = async (
               return {
                 identifier: id,
                 type: "webcontent",
-                file: {
-                  href: attachment.filePath,
-                },
+                files: [
+                  {
+                    href: attachment.filePath,
+                  },
+                ],
               };
             })
           : []

--- a/src/imscc/coursePackager/packager.ts
+++ b/src/imscc/coursePackager/packager.ts
@@ -134,7 +134,6 @@ export const packageCourse = async (
       },
     ],
   };
-  const organizationModuleItem: ImsItem[] = modules.map(moduleItem);
 
   const resources = resourcePages
     .map(pageResource)
@@ -142,6 +141,8 @@ export const packageCourse = async (
     .concat(globalDependencies);
 
   resources.push(courseSettingResources);
+
+  const organizationModuleItem: ImsItem[] = modules.map(moduleItem);
 
   const manifest: ImsManifest = {
     generatorComment,

--- a/src/imscc/resource.ts
+++ b/src/imscc/resource.ts
@@ -42,17 +42,21 @@ export const pageResource = (page: ResourcePage): ImsResource => {
       identifier: page.id,
       type,
       href: page.filePath,
-      file: {
-        href: page.filePath,
-      },
+      files: [
+        {
+          href: page.filePath,
+        },
+      ],
     };
   } else if (page.type === "discussion") {
     resource = {
       identifier: page.id,
       type,
-      file: {
-        href: page.filePath,
-      },
+      files: [
+        {
+          href: page.filePath,
+        },
+      ],
     };
   } else {
     throw new Error(`Unsupported page type: ${page.type}`);

--- a/src/imscc/types.ts
+++ b/src/imscc/types.ts
@@ -8,7 +8,8 @@ export type ImsResourceType =
   | "webcontent"
   | "imswl_xmlv1p1"
   | "imsdt_xmlv1p1"
-  | "imsqti_xmlv1p2/imscc_xmlv1p1/assessment";
+  | "imsqti_xmlv1p2/imscc_xmlv1p1/assessment"
+  | "associatedcontent/imscc_xmlv1p1/learning-application-resource";
 
 export type LmsType = "canvas" | "moodle";
 


### PR DESCRIPTION
We need to add to IMSCC a folder called "course_settings", inside which we have:
- course_settings.xml (mostly empty placeholder)
- module_meta.xml (re-iterates the module layout)
- files_meta.xml (mostly empty placeholder)
- canvas_export.txt (doesn't matter what's in it)

in the imsmanifest.xml reference these files